### PR TITLE
Add semi-automated tagging and generating GH Release draft to CICD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,18 +17,84 @@
 name: Release
 on:
   workflow_dispatch:
+    inputs:
+      tagName:
+        description: 'Name of git tag to be created, and then released. Must have syntax "v[0-9]+.[0-9]+.[0-9]+".'
+        required: true
 
 jobs:
-  publish:
+  tag:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Validate format of received tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const newTag = core.getInput('tag-name');
+            const regex = /^v[0-9]+\.[0-9]+\.[0-9]+$/;
+            
+            if (!regex.test(newTag)) {
+              core.setFailed('Tag does not match the required format "v[0-9]+.[0-9]+.[0-9]+"');
+              return;
+            }
+          tag-name: ${{ github.event.inputs.tagName }}
+      - name: Create and push tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = core.getInput('tag-name')
+            const ref = `refs/tags/${tag}`;
+            const sha = context.sha; // The SHA of the commit to tag
+        
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: ref,
+              sha: sha
+            });
+        
+            console.log(`Tag created: ${tag}`);
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tag-name: ${{ github.event.inputs.tagName }}
+
+  release:
+    needs: tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ github.event.inputs.tagName }}
+      - name: Generate release notes
+        id: generate_release_notes
+        uses: AbsaOSS/generate-release-notes@0.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          chapters: |
+            [
+              {"title": "Breaking Changes 💥", "label": "breaking-change"},
+              {"title": "New Features 🎉", "label": "enhancement"},
+              {"title": "Bugfixes 🛠", "label": "bug"}
+            ]
+          warnings: true
+      - name: Create draft release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ github.event.inputs.tagName }}
+          body: ${{ steps.generate_release_notes.outputs.releaseNotes }}
+          draft: true
+          prerelease: false
       - uses: olafurpg/setup-scala@v14
         with:
-          java-version: "adopt@1.8"
-      - run: sbt ci-release
+          java-version: "openjdk@1.17.0"
+      - name: Release to Sonatype and Maven Central
+        run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,15 @@ jobs:
           body: ${{ steps.generate_release_notes.outputs.releaseNotes }}
           draft: true
           prerelease: false
+
+  publish:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ github.event.inputs.tagName }}
       - uses: olafurpg/setup-scala@v14
         with:
           java-version: "openjdk@1.17.0"

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 
-name: Release
+name: Release - create draft release
 on:
   workflow_dispatch:
     inputs:
       tagName:
-        description: 'Name of git tag to be created, and then released. Must have syntax "v[0-9]+.[0-9]+.[0-9]+".'
+        description: 'Name of git tag to be created, and then draft release created. Syntax: "v[0-9]+.[0-9]+.[0-9]+".'
         required: true
 
 jobs:
@@ -90,22 +90,3 @@ jobs:
           body: ${{ steps.generate_release_notes.outputs.releaseNotes }}
           draft: true
           prerelease: false
-
-  publish:
-    needs: release
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: refs/tags/${{ github.event.inputs.tagName }}
-      - uses: olafurpg/setup-scala@v14
-        with:
-          java-version: "openjdk@1.17.0"
-      - name: Release to Sonatype and Maven Central
-        run: sbt ci-release
-        env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -1,0 +1,37 @@
+#
+# Copyright 2023 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Release - publish artifacts
+on:
+  release:
+    types: [released]
+
+jobs:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: olafurpg/setup-scala@v14
+      with:
+        java-version: "openjdk@1.17.0"
+    - name: Build and release to Sonatype and Maven Central
+      run: sbt ci-release
+      env:
+        PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+        PGP_SECRET: ${{ secrets.PGP_SECRET }}
+        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -16,23 +16,23 @@
 
 name: Release - publish artifacts
 on:
-  workflow_dispatch:
-#  release:
-#    types: [released]
+  release:
+    types: [released]
 
 jobs:
-  runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - uses: olafurpg/setup-scala@v14
-      with:
-        java-version: "openjdk@1.17.0"
-    - name: Build and release to Sonatype and Maven Central
-      run: sbt ci-release
-      env:
-        PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        PGP_SECRET: ${{ secrets.PGP_SECRET }}
-        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: olafurpg/setup-scala@v14
+        with:
+          java-version: "openjdk@1.17.0"
+      - name: Build and release to Sonatype and Maven Central
+        run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -16,8 +16,9 @@
 
 name: Release - publish artifacts
 on:
-  release:
-    types: [released]
+  workflow_dispatch:
+#  release:
+#    types: [released]
 
 jobs:
   runs-on: ubuntu-latest


### PR DESCRIPTION
- changed JDK version to `openjdk@1.17.01` in `publish` job, as this was already needed in CI
- spit release workflow into two:
   - `release_draft` with:
      - `tag` job that creates and pushes a git tag (name is specified as the workflow input)
      - `release` job that creates a draft release with notes derived from closed issues
   - `release_publish` with `publish` job that was previously in the `release` workflow; now it should be triggered once release created by `release_draft` is finalised and converted from draft to release