### PR TITLE
Fix example applications

### DIFF
--- a/examples/springdoc-openapi-scala-1/README.md
+++ b/examples/springdoc-openapi-scala-1/README.md
@@ -1,0 +1,41 @@
+# springdoc-openapi-scala-2 Example Application
+
+This is a simple example application demonstrating the use of springdoc-openapi-scala with Spring Boot 2.x.
+
+## Prerequisites
+
+- JDK 17 or higher
+- SBT 1.x
+- Scala 2.12.x
+
+## Running the Application
+
+To run the application with hot-reload enabled:
+
+```bash
+cd springdoc-openapi-scala/examples/springdoc-openapi-scala-1/simple
+sbt compile
+sbt "~reStart"
+```
+
+The `~reStart` command will automatically restart the application when source files change.
+
+## Accessing the API Documentation
+
+Once the application is running, you can access the OpenAPI documentation at:
+
+- OpenAPI JSON: http://localhost:8080/v3/api-docs
+
+## Features Demonstrated
+
+- Integration of springdoc-openapi with Scala classes
+- Automatic schema generation for Scala case classes
+- Support for complex type hierarchies
+- Custom schema customization
+
+## Project Structure
+
+- `src/main/scala/.../Application.scala` - Spring Boot application entry point
+- `src/main/scala/.../OpenAPIConfiguration.scala` - OpenAPI configuration
+- `src/main/scala/.../controller/` - REST controllers
+- `src/main/scala/.../model/` - Data models

--- a/examples/springdoc-openapi-scala-1/README.md
+++ b/examples/springdoc-openapi-scala-1/README.md
@@ -14,6 +14,7 @@ To run the application with hot-reload enabled:
 
 ```bash
 cd springdoc-openapi-scala/examples/springdoc-openapi-scala-1/simple
+sed -i '' 's/`springdoc-openapi-scala-1-version`: String = \?\?\?/`springdoc-openapi-scala-1-version`: String = "0.3.2"/g' build.sbt # Omit '' after the -i flag if not on mac
 sbt compile
 sbt "~reStart"
 ```

--- a/examples/springdoc-openapi-scala-1/simple/build.sbt
+++ b/examples/springdoc-openapi-scala-1/simple/build.sbt
@@ -16,7 +16,7 @@
 
 ThisBuild / scalaVersion := "2.12.18"
 
-lazy val `springdoc-openapi-scala-1-version`: String = ??? // specify version of the library, for example "0.2.0"
+lazy val `springdoc-openapi-scala-1-version`: String = "0.3.1" // specify version of the library, for example "0.2.0"
 
 lazy val root = (project in file("."))
   .settings(

--- a/examples/springdoc-openapi-scala-1/simple/build.sbt
+++ b/examples/springdoc-openapi-scala-1/simple/build.sbt
@@ -24,7 +24,8 @@ lazy val root = (project in file("."))
       "za.co.absa" %% "springdoc-openapi-scala-1" % `springdoc-openapi-scala-1-version`,
       "org.springdoc" % "springdoc-openapi-webmvc-core" % "1.7.0",
       "org.springframework.boot" % "spring-boot-starter-web" % "2.6.6",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.16.1"
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.16.1",
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value
     ),
     webappWebInfClasses := true,
     inheritJarManifest := true

--- a/examples/springdoc-openapi-scala-1/simple/build.sbt
+++ b/examples/springdoc-openapi-scala-1/simple/build.sbt
@@ -16,7 +16,7 @@
 
 ThisBuild / scalaVersion := "2.12.18"
 
-lazy val `springdoc-openapi-scala-1-version`: String = "0.3.1" // specify version of the library, for example "0.2.0"
+lazy val `springdoc-openapi-scala-1-version`: String = ??? // specify version of the library, for example "0.2.0"
 
 lazy val root = (project in file("."))
   .settings(

--- a/examples/springdoc-openapi-scala-1/simple/project/plugins.sbt
+++ b/examples/springdoc-openapi-scala-1/simple/project/plugins.sbt
@@ -15,3 +15,4 @@
  */
 
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "4.2.4")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")

--- a/examples/springdoc-openapi-scala-1/simple/src/main/scala/za/co/absa/springdocopenapiscala/examples/simple/OpenAPIConfiguration.scala
+++ b/examples/springdoc-openapi-scala-1/simple/src/main/scala/za/co/absa/springdocopenapiscala/examples/simple/OpenAPIConfiguration.scala
@@ -19,7 +19,7 @@ package za.co.absa.springdocopenapiscala.examples.simple
 import com.fasterxml.jackson.databind.JsonNode
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
-import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
 import org.springdoc.core.customizers.OpenApiCustomiser
 import org.springframework.context.annotation.{Bean, Configuration}
 import za.co.absa.springdocopenapiscala.{Bundle, OpenAPIModelRegistration}
@@ -39,8 +39,7 @@ class OpenAPIConfiguration {
     ),
     OpenAPIModelRegistration.ExtraTypesHandling.simpleMapping {
       case t if t =:= typeOf[JsonNode] =>
-        val schema = new Schema
-        schema.setType("string")
+        val schema = new StringSchema
         schema.setFormat("json")
         schema
     }

--- a/examples/springdoc-openapi-scala-2/simple/README.md
+++ b/examples/springdoc-openapi-scala-2/simple/README.md
@@ -14,6 +14,9 @@ To run the application with hot-reload enabled:
 
 ```bash
 cd springdoc-openapi-scala/examples/springdoc-openapi-scala-2/simple
+```suggestion
+cd springdoc-openapi-scala/examples/springdoc-openapi-scala-2/simple
+sed -i '' 's/`springdoc-openapi-scala-2-version`: String = \?\?\?/`springdoc-openapi-scala-2-version`: String = "0.3.2"/g' build.sbt # Omit '' after the -i flag if not on mac
 sbt compile
 sbt "~reStart"
 ```

--- a/examples/springdoc-openapi-scala-2/simple/README.md
+++ b/examples/springdoc-openapi-scala-2/simple/README.md
@@ -1,0 +1,41 @@
+# springdoc-openapi-scala-2 Example Application
+
+This is a simple example application demonstrating the use of springdoc-openapi-scala with Spring Boot 3.x.
+
+## Prerequisites
+
+- JDK 17 or higher
+- SBT 1.x
+- Scala 2.12.x
+
+## Running the Application
+
+To run the application with hot-reload enabled:
+
+```bash
+cd springdoc-openapi-scala/examples/springdoc-openapi-scala-2/simple
+sbt compile
+sbt "~reStart"
+```
+
+The `~reStart` command will automatically restart the application when source files change.
+
+## Accessing the API Documentation
+
+Once the application is running, you can access the OpenAPI documentation at:
+
+- OpenAPI JSON: http://localhost:8080/v3/api-docs
+
+## Features Demonstrated
+
+- Integration of springdoc-openapi with Scala classes
+- Automatic schema generation for Scala case classes
+- Support for complex type hierarchies
+- Custom schema customization
+
+## Project Structure
+
+- `src/main/scala/.../Application.scala` - Spring Boot application entry point
+- `src/main/scala/.../OpenAPIConfiguration.scala` - OpenAPI configuration
+- `src/main/scala/.../controller/` - REST controllers
+- `src/main/scala/.../model/` - Data models

--- a/examples/springdoc-openapi-scala-2/simple/README.md
+++ b/examples/springdoc-openapi-scala-2/simple/README.md
@@ -14,8 +14,6 @@ To run the application with hot-reload enabled:
 
 ```bash
 cd springdoc-openapi-scala/examples/springdoc-openapi-scala-2/simple
-```suggestion
-cd springdoc-openapi-scala/examples/springdoc-openapi-scala-2/simple
 sed -i '' 's/`springdoc-openapi-scala-2-version`: String = \?\?\?/`springdoc-openapi-scala-2-version`: String = "0.3.2"/g' build.sbt # Omit '' after the -i flag if not on mac
 sbt compile
 sbt "~reStart"

--- a/examples/springdoc-openapi-scala-2/simple/build.sbt
+++ b/examples/springdoc-openapi-scala-2/simple/build.sbt
@@ -16,7 +16,7 @@
 
 ThisBuild / scalaVersion := "2.12.18"
 
-lazy val `springdoc-openapi-scala-2-version`: String = "0.3.1" // specify version of the library
+lazy val `springdoc-openapi-scala-2-version`: String = ??? // specify version of the library
 
 lazy val root = (project in file("."))
   .settings(

--- a/examples/springdoc-openapi-scala-2/simple/build.sbt
+++ b/examples/springdoc-openapi-scala-2/simple/build.sbt
@@ -16,14 +16,14 @@
 
 ThisBuild / scalaVersion := "2.12.18"
 
-lazy val `springdoc-openapi-scala-2-version`: String = ??? // specify version of the library, for example "0.2.0"
+lazy val `springdoc-openapi-scala-2-version`: String = "0.3.1" // specify version of the library
 
 lazy val root = (project in file("."))
   .settings(
     libraryDependencies ++= Seq(
       "za.co.absa" %% "springdoc-openapi-scala-2" % `springdoc-openapi-scala-2-version`,
       "org.springdoc" % "springdoc-openapi-starter-webmvc-api" % "2.8.9",
-      "org.springframework.boot" % "spring-boot-starter-web" % "3.2.0",
+      "org.springframework.boot" % "spring-boot-starter-web" % "3.4.3",
       "org.playframework" %% "play-json" % "3.0.1"
     ),
     webappWebInfClasses := true,

--- a/examples/springdoc-openapi-scala-2/simple/build.sbt
+++ b/examples/springdoc-openapi-scala-2/simple/build.sbt
@@ -16,7 +16,7 @@
 
 ThisBuild / scalaVersion := "2.12.18"
 
-lazy val `springdoc-openapi-scala-2-version`: String = ??? // specify version of the library
+lazy val `springdoc-openapi-scala-2-version`: String = ??? // specify version of the library, for example "0.2.0"
 
 lazy val root = (project in file("."))
   .settings(

--- a/examples/springdoc-openapi-scala-2/simple/project/plugins.sbt
+++ b/examples/springdoc-openapi-scala-2/simple/project/plugins.sbt
@@ -15,3 +15,4 @@
  */
 
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "4.2.4")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")

--- a/examples/springdoc-openapi-scala-2/simple/src/main/scala/za/co/absa/springdocopenapiscala/examples/simple/OpenAPIConfiguration.scala
+++ b/examples/springdoc-openapi-scala-2/simple/src/main/scala/za/co/absa/springdocopenapiscala/examples/simple/OpenAPIConfiguration.scala
@@ -18,7 +18,7 @@ package za.co.absa.springdocopenapiscala.examples.simple
 
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.info.Info
-import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
 import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springframework.context.annotation.{Bean, Configuration}
 import play.api.libs.json.JsValue
@@ -40,8 +40,7 @@ class OpenAPIConfiguration {
     ),
     OpenAPIModelRegistration.ExtraTypesHandling.simpleMapping {
       case t if t =:= typeOf[JsValue] =>
-        val schema = new Schema
-        schema.setType("string")
+        val schema = new StringSchema
         schema.setFormat("json")
         schema
     }

--- a/publish.sbt
+++ b/publish.sbt
@@ -35,6 +35,12 @@ ThisBuild / developers := List(
     name  = "Kevin Wallimann",
     email = "kevin.wallimann@absa.africa",
     url   = url("https://github.com/kevinwallimann")
+  ),
+  Developer(
+    id    = "AlexGuzmanAtAbsa",
+    name  = "Alejandro Guzman",
+    email = "alex.guzman@absa.africa",
+    url   = url("https://github.com/AlexGuzmanAtAbsa")
   )
 )
 


### PR DESCRIPTION
Fixes Spring boot startup behaviur which caused each example applications to shut down as soon as it starts. 
- Uses Revolver plugin fo fix startup
- Use StringSchema instead of Schema in custom mappings example(s)
- Add README.md files  for example projects

To run:

```
cd springdoc-openapi-scala/examples/springdoc-openapi-scala-2/simple 
sbt compile && sbt "~reStart"
```

OpenAPI JSON schema is available at:
http://localhost:8080/v3/api-docs

    