### PR TITLE
Upgrade sbt-ci-release

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")
 addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.9.2")
 
 addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.1")


### PR DESCRIPTION
According to https://github.com/sbt/sbt-ci-release 1.9.3 is the latest version that should be used after the OSSRH end-of-life.